### PR TITLE
Added french locale

### DIFF
--- a/_locales/fr/motorbit-strings.json
+++ b/_locales/fr/motorbit-strings.json
@@ -1,0 +1,10 @@
+{
+  "motorbit.back|block": "reculer à %n de puissance",
+  "motorbit.brake|block": "arrêter les moteurs",
+  "motorbit.forward|block": "avancer à %n de puissance",
+  "motorbit.freestyle|block": "moteur gauche %m| moteur droit %n",
+  "motorbit.turnleft|block": "tourner à gauche à %n de puissance",
+  "motorbit.turnright|block": "tourner à droite à %n de puissance",
+  "motorbit|block": "motorbit",
+  "{id:category}Motorbit": "Motorbit"
+}

--- a/pxt.json
+++ b/pxt.json
@@ -10,7 +10,8 @@
     "files": [
         "README.md",
         "motorbit.ts",
-        "_locales/zh/motorbit-strings.json"
+        "_locales/zh/motorbit-strings.json",
+        "_locales/fr/motorbit-strings.json"
     ],
     "testFiles": [
         "tests.ts"


### PR DESCRIPTION
Hey guys,

We're using this extension at Ateliers Kikicode for STEM courses.
I added french locales since most of our classes are given in french.

Could we publish a new release once the PR is accepted? I think this is required for makecode to update the extension, [we've experienced this in the past](https://github.com/tinkertanker/pxt-joystickbit/pull/1)

Let me know if anything is needed from my end!

Thank you for the wonderful hardware and software, we use and like them a lot.

*Matías*
